### PR TITLE
#3 support @Reflectable on enums;

### DIFF
--- a/src/main/java/com/formkiq/graalvm/processors/GraalvmReflectAnnontationProcessor.java
+++ b/src/main/java/com/formkiq/graalvm/processors/GraalvmReflectAnnontationProcessor.java
@@ -95,6 +95,7 @@ public class GraalvmReflectAnnontationProcessor extends AbstractProcessor {
       case METHOD:
         className = ((TypeElement) element.getEnclosingElement()).getQualifiedName().toString();
         break;
+      case ENUM:
       case CLASS:
         className = ((TypeElement) element).getQualifiedName().toString();
         break;
@@ -461,7 +462,7 @@ public class GraalvmReflectAnnontationProcessor extends AbstractProcessor {
             reflect.addMethod(methodName, parameterTypes);
 
             break;
-
+          case ENUM:
           case CLASS:
             reflect = processClass(reflect, reflectable);
             break;

--- a/src/test/java/com/formkiq/graalvm/processors/GraalvmReflectAnnontationProcessorTest.java
+++ b/src/test/java/com/formkiq/graalvm/processors/GraalvmReflectAnnontationProcessorTest.java
@@ -575,4 +575,32 @@ public class GraalvmReflectAnnontationProcessorTest {
     assertNull(map.get(1).get("fields"));
     assertNull(map.get(1).get("methods"));
   }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testEnumAnnotations() throws IOException {
+    Compilation compilation =
+        javac()
+            .withProcessors(new GraalvmReflectAnnontationProcessor())
+            .compile(
+                JavaFileObjects.forSourceString(
+                    "TestEnum",
+                    "import com.formkiq.graalvm.annotations.Reflectable;\n"
+                        + "@Reflectable\n"
+                        + "public enum TestEnum {\n"
+                        + "  REFLECTED_ENUM_ONE,\n"
+                        + "  REFLECTED_ENUM_TWO\n"
+                        + "}"));
+
+    List<Map<String, Object>> map = getReflectConf(compilation);
+
+    assertEquals(1, map.size());
+    assertEquals("TestEnum", map.get(0).get("name"));
+    assertEquals(Boolean.TRUE, map.get(0).get("allPublicConstructors"));
+    assertEquals(Boolean.TRUE, map.get(0).get("allPublicMethods"));
+    assertEquals(Boolean.TRUE, map.get(0).get("allPublicFields"));
+    assertEquals(Boolean.FALSE, map.get(0).get("allDeclaredConstructors"));
+    assertEquals(Boolean.TRUE, map.get(0).get("allDeclaredMethods"));
+    assertEquals(Boolean.TRUE, map.get(0).get("allDeclaredFields"));
+  }
 }


### PR DESCRIPTION
Fix for the problem described in #3. 

The enum classes were previously not handled, made GraalvmReflectAnnontationProcessor class handle enums just like they were regular classes.

All tests pass.